### PR TITLE
SHOWCASE-4375 Step 1 context on other steps 

### DIFF
--- a/agentic_ai_backend/agents/formsupportagent/formsupport_agent_a2a_server.py
+++ b/agentic_ai_backend/agents/formsupportagent/formsupport_agent_a2a_server.py
@@ -2,6 +2,7 @@
 FastAPI A2A Wrapper for Form Support Agent
 This is a standalone wrapper that imports and exposes the FormSupportAgent via HTTP
 """
+import ast
 import json
 import logging
 import os
@@ -83,9 +84,54 @@ def _agent_cache_key(step_key: str, client_settings: FormSupportAgentClientSetti
 _HISTORY_SOURCE_ID = "in_memory"
 
 
+def _extract_aggregator_response(text: str) -> str:
+    """Reduce a stored orchestrator assistant turn to just the Aggregator's response.
+
+    The orchestrator persists its workflow output as a Python-repr string of a list of
+    payload dicts, e.g.::
+
+        [{'source': 'Aggregator', 'response': '<curated text>', 'original_results': [...]}]
+
+    Only the Aggregator's ``response`` is useful as conversation context; ``original_results``
+    (raw sub-agent payloads) and non-Aggregator entries are dropped. Falls back to the raw
+    text when it can't be parsed or no Aggregator payload is present.
+    """
+    stripped = (text or "").strip()
+    if not stripped or stripped[0] not in "[{":
+        return text
+    try:
+        parsed = ast.literal_eval(stripped)
+    except (ValueError, SyntaxError):
+        try:
+            parsed = json.loads(stripped)
+        except (ValueError, TypeError):
+            return text
+
+    items = parsed if isinstance(parsed, list) else [parsed]
+    for item in items:
+        if isinstance(item, dict) and item.get("source") == "Aggregator":
+            response = item.get("response")
+            if isinstance(response, str):
+                return response
+            if response is not None:
+                return json.dumps(response)
+    return text
+
+
 def _seed_messages(history) -> list[Message]:
-    """Convert orchestrator-provided {role, text} turns into MAF Message objects."""
-    return [Message(turn.role, [turn.text]) for turn in history if turn.text and turn.role in ("user", "assistant")]
+    """Convert orchestrator-provided {role, text} turns into MAF Message objects.
+
+    Assistant turns arrive as the orchestrator's full workflow payload; only the
+    Aggregator's curated ``response`` is kept (see ``_extract_aggregator_response``).
+    """
+    messages: list[Message] = []
+    for turn in history:
+        if not turn.text or turn.role not in ("user", "assistant"):
+            continue
+        text = _extract_aggregator_response(turn.text) if turn.role == "assistant" else turn.text
+        if text and text.strip():
+            messages.append(Message(turn.role, [text]))
+    return messages
 
 
 def _evict_expired_agents() -> None:
@@ -206,9 +252,7 @@ async def invoke_agent(request: InvokeRequest):
         # Get agent instance for this step
         agent = get_agent(step_identifier, client_settings=request.client_settings)
 
-        # Resolve session for this session+step combination
-        print(f"[HISTDEBUG] invoke session={request.session_id} step={step_identifier} "
-              f"history_turns={len(request.history) if request.history else 0}")
+
         session = None
         if request.session_id:
             session_key = (request.session_id, str(step_identifier))
@@ -220,11 +264,12 @@ async def invoke_agent(request: InvokeRequest):
                         if turn.role in ("user", "assistant") and turn.text:
                             print(f"[HISTDEBUG] cache MISS -> seeding session {session_key} with turn: role={turn.role}, text={turn.text}")
                     seeded = _seed_messages(request.history)
+                    for turn in seeded:
+                        print(f"[HISTDEBUG] cache MISS -> seeded message: role={turn.role}, text={turn.text}")
                     # Seed into the history provider's source-scoped state, not the top-level
                     # state dict — the InMemoryHistoryProvider only reads state["in_memory"]["messages"].
                     session.state.setdefault(_HISTORY_SOURCE_ID, {})["messages"] = seeded
-                    print(f"[HISTDEBUG] cache MISS -> seeded new session {session_key} "
-                          f"with {len(seeded)} messages")
+                   
                 else:
                     print(f"[HISTDEBUG] cache MISS -> new session {session_key}, no history provided")
                 # Persist the freshly created session so subsequent turns reuse it (cache HIT)

--- a/agentic_ai_backend/agents/formsupportagent/formsupport_agent_a2a_server.py
+++ b/agentic_ai_backend/agents/formsupportagent/formsupport_agent_a2a_server.py
@@ -76,9 +76,16 @@ def _agent_cache_key(step_key: str, client_settings: FormSupportAgentClientSetti
     return (client_id, fingerprint, step_key)
 
 
+# Source ID the framework's auto-injected InMemoryHistoryProvider reads/writes under.
+# History must be seeded into session.state[_HISTORY_SOURCE_ID]["messages"], NOT the
+# top-level session.state["messages"], because providers receive a source-scoped state dict
+# (see agent_framework _agents.py: state=provider_session.state.setdefault(provider.source_id, {})).
+_HISTORY_SOURCE_ID = "in_memory"
+
+
 def _seed_messages(history) -> list[Message]:
     """Convert orchestrator-provided {role, text} turns into MAF Message objects."""
-    return [Message(turn.role, [turn.text]) for turn in history if turn.text and turn.role in ("user")]
+    return [Message(turn.role, [turn.text]) for turn in history if turn.text and turn.role in ("user", "assistant")]
 
 
 def _evict_expired_agents() -> None:
@@ -210,13 +217,19 @@ async def invoke_agent(request: InvokeRequest):
                 session = agent.agent.create_session(session_id=request.session_id)
                 if request.history:
                     for turn in request.history:
-                        if turn.role == "user" and turn.text:
+                        if turn.role in ("user", "assistant") and turn.text:
                             print(f"[HISTDEBUG] cache MISS -> seeding session {session_key} with turn: role={turn.role}, text={turn.text}")
-                    session.state["messages"] = _seed_messages(request.history)
+                    seeded = _seed_messages(request.history)
+                    # Seed into the history provider's source-scoped state, not the top-level
+                    # state dict — the InMemoryHistoryProvider only reads state["in_memory"]["messages"].
+                    session.state.setdefault(_HISTORY_SOURCE_ID, {})["messages"] = seeded
                     print(f"[HISTDEBUG] cache MISS -> seeded new session {session_key} "
-                          f"with {len(session.state['messages'])} messages")
+                          f"with {len(seeded)} messages")
                 else:
                     print(f"[HISTDEBUG] cache MISS -> new session {session_key}, no history provided")
+                # Persist the freshly created session so subsequent turns reuse it (cache HIT)
+                # and the framework's after_run-saved history accumulates across requests.
+                _session_threads[session_key] = session
             else:
                 print(f"[HISTDEBUG] cache HIT for {session_key} (using existing in-memory session)")
         # Run the agent with the cleaned query (or original if no step was found)

--- a/agentic_ai_backend/agents/formsupportagent/formsupport_agent_a2a_server.py
+++ b/agentic_ai_backend/agents/formsupportagent/formsupport_agent_a2a_server.py
@@ -9,7 +9,7 @@ import sys
 import time
 from dataclasses import dataclass
 from fastapi import FastAPI, HTTPException
-from agent_framework import AgentSession
+from agent_framework import AgentSession, Message
 from dotenv import load_dotenv
 
 # Add parent directories to path to allow importing modules
@@ -74,6 +74,11 @@ _AGENT_CACHE_TTL_SECONDS = float(os.getenv("FORM_SUPPORT_AGENT_CACHE_TTL_SECONDS
 def _agent_cache_key(step_key: str, client_settings: FormSupportAgentClientSettings) -> tuple[str, str, str]:
     client_id, fingerprint = settings_cache_parts(client_settings)
     return (client_id, fingerprint, step_key)
+
+
+def _seed_messages(history) -> list[Message]:
+    """Convert orchestrator-provided {role, text} turns into MAF Message objects."""
+    return [Message(turn.role, [turn.text]) for turn in history if turn.text and turn.role in ("user")]
 
 
 def _evict_expired_agents() -> None:
@@ -195,13 +200,25 @@ async def invoke_agent(request: InvokeRequest):
         agent = get_agent(step_identifier, client_settings=request.client_settings)
 
         # Resolve session for this session+step combination
+        print(f"[HISTDEBUG] invoke session={request.session_id} step={step_identifier} "
+              f"history_turns={len(request.history) if request.history else 0}")
         session = None
         if request.session_id:
             session_key = (request.session_id, str(step_identifier))
             session = _session_threads.get(session_key)
             if session is None:
                 session = agent.agent.create_session(session_id=request.session_id)
-                _session_threads[session_key] = session
+                if request.history:
+                    for turn in request.history:
+                        if turn.role == "user" and turn.text:
+                            print(f"[HISTDEBUG] cache MISS -> seeding session {session_key} with turn: role={turn.role}, text={turn.text}")
+                    session.state["messages"] = _seed_messages(request.history)
+                    print(f"[HISTDEBUG] cache MISS -> seeded new session {session_key} "
+                          f"with {len(session.state['messages'])} messages")
+                else:
+                    print(f"[HISTDEBUG] cache MISS -> new session {session_key}, no history provided")
+            else:
+                print(f"[HISTDEBUG] cache HIT for {session_key} (using existing in-memory session)")
         # Run the agent with the cleaned query (or original if no step was found)
         result = await agent.run(query, session=session)
 

--- a/agentic_ai_backend/agents/formsupportagent/models/formsupportmodel.py
+++ b/agentic_ai_backend/agents/formsupportagent/models/formsupportmodel.py
@@ -24,11 +24,17 @@ class FormSupportAgentClientSettings(TypedDict):
     config: FormSupportAgentConfig
 
 
+class HistoryTurn(BaseModel):
+    role: str
+    text: str
+
+
 class InvokeRequest(BaseModel):
     query: str
     session_id: Optional[str] = None
     step_number: Union[int, str]  # Required step identifier
     client_settings: FormSupportAgentClientSettings
+    history: Optional[list[HistoryTurn]] = None
 
 
 class InvokeResponse(BaseModel):

--- a/agentic_ai_backend/agents/orchestrators/orchestratoragent.py
+++ b/agentic_ai_backend/agents/orchestrators/orchestratoragent.py
@@ -175,6 +175,11 @@ async def orchestrate_a2a(query: str,
     conversation_agent_enabled = tenant_settings.conversation.enabled if tenant_settings.conversation else None
     form_support_agent_enabled = tenant_settings.form_support.enabled if tenant_settings.form_support else None
 
+    # Option 1: orchestrator owns durable session state in Redis and forwards a
+    # curated slice of the conversation to the stateless sub-agents.
+    db_utils = get_redis_utils()
+    prior_history = await db_utils.get_history_turns(effective_session_id)
+
     executors = []
     if conversation_agent_enabled:
         conversation_settings = tenant_settings.conversation
@@ -194,6 +199,7 @@ async def orchestrate_a2a(query: str,
             base_url=form_support_agent_url,
             step_number=effective_step_number,
             session_id=effective_session_id,
+            history=prior_history,
             client_settings=form_support_settings,
             timeout=a2a_timeout_seconds
         )
@@ -251,9 +257,6 @@ async def orchestrate_a2a(query: str,
 
 
     final_data = None
-
-    # Get singleton Redis Utils
-    db_utils = get_redis_utils()
 
     try:
         # Load session state

--- a/agentic_ai_backend/agents/orchestrators/threadmanagement/redisdbutils.py
+++ b/agentic_ai_backend/agents/orchestrators/threadmanagement/redisdbutils.py
@@ -2,7 +2,40 @@ from dotenv import load_dotenv
 from agent_framework import AgentSession
 from utils.redisservice import RedisService
 import os
+import re
 from .thread_manager_interface import IThreadManager
+
+# Leading "stepN-Name:" prefix the orchestrator prepends to user queries.
+_STEP_PREFIX_RE = re.compile(r"^step\d[\w-]*:\s*", re.IGNORECASE)
+
+
+def _message_role_text(msg) -> tuple[str | None, str]:
+    """Extract (role, text) from a MAF Message object or its serialized dict form."""
+    if isinstance(msg, dict):
+        role = msg.get("role")
+        text = " ".join(
+            c.get("text", "")
+            for c in msg.get("contents", [])
+            if isinstance(c, dict) and c.get("type") == "text"
+        )
+    else:
+        role = getattr(msg, "role", None)
+        text = getattr(msg, "text", "") or ""
+    return role, text.strip()
+
+
+def _extract_messages(state: dict) -> list:
+    """Return the stored message list, tolerating history-provider namespacing.
+
+    Messages may sit directly at ``state["messages"]`` or, more commonly, under a
+    history provider's source_id (e.g. ``state["in_memory"]["messages"]``).
+    """
+    if isinstance(state.get("messages"), list):
+        return state["messages"]
+    for value in state.values():
+        if isinstance(value, dict) and isinstance(value.get("messages"), list):
+            return value["messages"]
+    return []
 
 load_dotenv()
 
@@ -37,6 +70,37 @@ class redisdbutils(IThreadManager):
             session = agent.create_session(session_id=thread_id)
         
         return session
+
+    async def get_history_turns(self, thread_id: str, *, limit: int = 10) -> list[dict]:
+        """Return recent user/assistant turns for a thread as plain {role, text} dicts.
+
+        Curated context for cross-agent passing (Option 1): only user/assistant turns,
+        most-recent `limit`, tool/system messages dropped. Reads Redis directly and
+        tolerates a missing/corrupt thread by returning [].
+        """
+        if not thread_id:
+            return []
+        try:
+            thread_state = await self.redis_service.load_thread(thread_id)
+        except Exception as e:
+            print(f"Error loading history from Redis: {e}")
+            return []
+        if not thread_state:
+            return []
+
+        session = AgentSession.from_dict(thread_state)
+        messages = _extract_messages(session.state or {})
+
+        turns: list[dict] = []
+        for msg in messages:
+            role, text = _message_role_text(msg)
+            if role not in ("user", "assistant") or not text:
+                continue
+            if role == "user":
+                text = _STEP_PREFIX_RE.sub("", text).strip()
+            turns.append({"role": role, "text": text})
+
+        return turns[-limit:]
 
     async def save_thread_state(self, thread_id: str, thread):
         try:

--- a/agentic_ai_backend/agents/orchestrators/workflowcomponents/formsupportagentexecutor.py
+++ b/agentic_ai_backend/agents/orchestrators/workflowcomponents/formsupportagentexecutor.py
@@ -39,6 +39,7 @@ class FormSupportAgentA2AExecutor(Executor):
         name: str = "Form Support Agent (A2A)",
         instructions: str = "Handles form support queries using A2A protocol",
         session_id: str = None,
+        history: Optional[list] = None,
         *,
         client_settings: FormSupportAgentSettings,
         # Timeout in seconds for the HTTP A2A call to the Form Support Agent.
@@ -48,6 +49,7 @@ class FormSupportAgentA2AExecutor(Executor):
         self.client = FormSupportAgentA2AClient(base_url=base_url, timeout=timeout)
         self.step_number = step_number
         self.session_id = session_id
+        self.history = history or []
         # A2A requests are JSON payloads, so convert the typed settings at the boundary.
         self.client_settings = client_settings.model_dump(exclude_none=True)
 
@@ -85,6 +87,7 @@ class FormSupportAgentA2AExecutor(Executor):
                 session_id=self.session_id,
                 step_number=self.step_number,
                 client_settings=self.client_settings,
+                history=self.history,
             )
 
             # The form support agent emits raw JSON per its prompt template; parse it


### PR DESCRIPTION
Root cause of https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-4375
--------------------------------------------------------------------
History was seeded into the top-level session.state["messages"], but Microsoft Agent Framework's auto-injected InMemoryHistoryProvider reads from a source-scoped sub-dict (session.state["in_memory"]["messages"]). The key mismatch meant the seeded turns were never loaded.

Changes (formsupport_agent_a2a_server.py)

- Seed into the correct scoped key so the history provider actually loads prior turns (_HISTORY_SOURCE_ID = "in_memory").
- Include assistant turns in history (previously user-only), so the agent can resolve follow-up questions against its own prior answers.
- Persist the session into _session_threads on a cache MISS, so subsequent turns reuse it and framework-saved history accumulates in-process.
- Trim assistant history payloads — a new _extract_aggregator_response helper reduces each stored orchestrator turn to just the Aggregator's response, dropping the bulky original_results and non-Aggregator entries. Fails safe to raw text when unparseable.

Notes

- No API/schema changes; behavior-only fix.
- Extraction verified against both Python-repr (orchestrator default) and JSON payload formats.