### PR TITLE
Pass POSSE application_id to backend

### DIFF
--- a/ai_bot_frontend/client.js
+++ b/ai_bot_frontend/client.js
@@ -1368,10 +1368,8 @@ else {
                 onQuestionClick: handleGuidedQuestionClick
             });
             saveThreadId(sessionId);
-            /** We need to save the application ID to sessionStorage at the time the assistant initializes.
-             * This is because, application ID is present in the DOM on the main window but in popups, there is no applicationId anywhere in the DOM. 
-             * 
-             * So, we need to save the applicationId to sessionStorage when the assistant initializes. Because our first step is always in the main window, we are guaranteed to have access to the application ID in the popups.
+            /** We need to save the application ID to sessionStorage at the time the assistant initializes because, 
+             * application ID is present in the DOM on the main window but absent in popups. 
              * */
             saveApplicationIdtoSessionStorage();
 

--- a/ai_bot_frontend/client.js
+++ b/ai_bot_frontend/client.js
@@ -134,7 +134,8 @@ else {
                 client_id: clientId,
                 query,
                 step_number,
-                session_id
+                session_id,
+                application_id: sessionStorage.getItem(APPLICATION_ID_STORAGE_PREFIX),
             };
 
             if (!socket || socket.readyState !== WebSocket.OPEN) {
@@ -210,9 +211,22 @@ else {
         };
         //-------------------------- Steppers Ends ---------------------------//
 
+        function parseApplicationIdFromDOM() {
+          const el = document.querySelector("span.title");
+          if (!el) {
+            console.warn("Application ID not found in the DOM.");
+            // This is not a catastrophic error, so we will return null instead of throwing an error.
+            return null;
+          }
+          // We will retrieve the application ID from the text content of the span.title element, which is expected to be in the format "Water Licence Application (123456)".
+          const match = el.textContent.match(/\((\d+)\)/);
+          return match ? match[1] : null;
+        }
+
         const THREAD_ID_STORAGE_KEY = 'nrAiForm_threadId';
         const CHAT_HISTORY_STORAGE_PREFIX = 'nrAiForm_chatHistory';
         const CHAT_SCROLL_STORAGE_PREFIX = 'nrAiForm_chatScroll';
+        const APPLICATION_ID_STORAGE_PREFIX = 'nrAiForm_applicationId';
 
         function createFallbackThreadId() {
             const randomBytes = new Uint8Array(16);
@@ -245,6 +259,14 @@ else {
             } catch (error) {
                 console.error("Unable to save thread ID to localStorage and sessionStorage:", error);
             }
+        }
+
+        function saveApplicationIdtoSessionStorage() {
+            if (sessionStorage.getItem(APPLICATION_ID_STORAGE_PREFIX)) {
+                // If the application ID is already in sessionStorage, we don't need to set it in the storage again.
+                return;
+            }
+            sessionStorage.setItem(APPLICATION_ID_STORAGE_PREFIX, parseApplicationIdFromDOM());
         }
 
         function getHistoryStorageKey(threadId) {
@@ -1346,6 +1368,13 @@ else {
                 onQuestionClick: handleGuidedQuestionClick
             });
             saveThreadId(sessionId);
+            /** We need to save the application ID to sessionStorage at the time the assistant initializes.
+             * This is because, application ID is present in the DOM on the main window but in popups, there is no applicationId anywhere in the DOM. 
+             * 
+             * So, we need to save the applicationId to sessionStorage when the assistant initializes. Because our first step is always in the main window, we are guaranteed to have access to the application ID in the popups.
+             * */
+            saveApplicationIdtoSessionStorage();
+
             const existingHistory = loadChatHistory(sessionId);
             if (existingHistory.length > 0) {
                 renderHistoryEntries(existingHistory, false);
@@ -1880,6 +1909,13 @@ else {
             try {
                 localStorage.removeItem(THREAD_ID_STORAGE_KEY);
                 sessionStorage.removeItem(THREAD_ID_STORAGE_KEY);
+
+                /**
+                 * We do not have to clear the application ID from sessionStorage because, user may
+                 * start a new chat session by manually clearing the chat session for the same applicationId.
+                 * *  
+                 * */ 
+
                 const keysToRemove = [];
                 for (let i = 0; i < localStorage.length; i++) {
                     const key = localStorage.key(i);


### PR DESCRIPTION
Considerations:

- `applicationId` is present in POSSE only on main window
- On Popups, there is no `applicationId` anywhere on the DOM. This means, we need to capture the `applicationId` from the main window and share it with popups.

Following these considerations, we use `sessionStorage` so that popups can use the `applicationId`.