### PR TITLE
Update applicationId in sessionStorage if applicationId changes

### DIFF
--- a/ai_bot_frontend/client.js
+++ b/ai_bot_frontend/client.js
@@ -262,11 +262,13 @@ else {
         }
 
         function saveApplicationIdtoSessionStorage() {
-            if (sessionStorage.getItem(APPLICATION_ID_STORAGE_PREFIX)) {
-                // If the application ID is already in sessionStorage, we don't need to set it in the storage again.
+            const applicationIdInDOM = parseApplicationIdFromDOM();
+            const applicationIdInSessionStorage = sessionStorage.getItem(APPLICATION_ID_STORAGE_PREFIX);
+            if (applicationIdInSessionStorage && applicationIdInSessionStorage === applicationIdInDOM) {
+                // If the application ID in sessionStorage matches the one in the DOM, we don't need to set it in the storage again.
                 return;
             }
-            sessionStorage.setItem(APPLICATION_ID_STORAGE_PREFIX, parseApplicationIdFromDOM());
+            sessionStorage.setItem(APPLICATION_ID_STORAGE_PREFIX, applicationIdInDOM);
         }
 
         function getHistoryStorageKey(threadId) {


### PR DESCRIPTION
Why is this change needed?
- POSSE has modified Step 1 Introduction to be a standalone page on the form and hence, there's no next button on this page. The only way a user can go to step 2 is by clicking `Apply without BCeID` again. However, when they hop from step 1 to step 2, this is now treated as a new application and hence we get a new `applicationId`. This calls for a change to our `applicationId` in `sessionStorage`.
